### PR TITLE
Remove singleton instance

### DIFF
--- a/incubator/metricbeat/metricbeat-kubernetes-uchicago-prod.yaml
+++ b/incubator/metricbeat/metricbeat-kubernetes-uchicago-prod.yaml
@@ -197,70 +197,70 @@ data:
               - 'kubernetes.labels.app'
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
-apiVersion: apps/v1beta1
-kind: Deployment
-metadata:
-  name: metricbeat
-  namespace: kube-system
-  labels:
-    k8s-app: metricbeat
-spec:
-  template:
-    metadata:
-      labels:
-        k8s-app: metricbeat
-    spec:
-      serviceAccountName: metricbeat
-      containers:
-      - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.4.2
-        args: [
-          "-c", "/etc/metricbeat.yml",
-          "-e",
-        ]
-        env:
-        - name: ELASTICSEARCH_HOST
-          value: elasticsearch
-        - name: ELASTICSEARCH_PORT
-          value: "9200"
-        - name: ELASTICSEARCH_USERNAME
-          value: elastic
-        - name: ELASTICSEARCH_PASSWORD
-          value: changeme
-        - name: ELASTIC_CLOUD_ID
-          value:
-        - name: ELASTIC_CLOUD_AUTH
-          value:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        securityContext:
-          runAsUser: 0
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        volumeMounts:
-        - name: config
-          mountPath: /etc/metricbeat.yml
-          readOnly: true
-          subPath: metricbeat.yml
-        - name: modules
-          mountPath: /usr/share/metricbeat/modules.d
-          readOnly: true
-      volumes:
-      - name: config
-        configMap:
-          defaultMode: 0600
-          name: metricbeat-config
-      - name: modules
-        configMap:
-          defaultMode: 0600
-          name: metricbeat-deployment-modules
----
+#apiVersion: apps/v1beta1
+#kind: Deployment
+#metadata:
+#  name: metricbeat
+#  namespace: kube-system
+#  labels:
+#    k8s-app: metricbeat
+#spec:
+#  template:
+#    metadata:
+#      labels:
+#        k8s-app: metricbeat
+#    spec:
+#      serviceAccountName: metricbeat
+#      containers:
+#      - name: metricbeat
+#        image: docker.elastic.co/beats/metricbeat:6.4.2
+#        args: [
+#          "-c", "/etc/metricbeat.yml",
+#          "-e",
+#        ]
+#        env:
+#        - name: ELASTICSEARCH_HOST
+#          value: elasticsearch
+#        - name: ELASTICSEARCH_PORT
+#          value: "9200"
+#        - name: ELASTICSEARCH_USERNAME
+#          value: elastic
+#        - name: ELASTICSEARCH_PASSWORD
+#          value: changeme
+#        - name: ELASTIC_CLOUD_ID
+#          value:
+#        - name: ELASTIC_CLOUD_AUTH
+#          value:
+#        - name: POD_NAMESPACE
+#          valueFrom:
+#            fieldRef:
+#              fieldPath: metadata.namespace
+#        securityContext:
+#          runAsUser: 0
+#        resources:
+#          limits:
+#            memory: 200Mi
+#          requests:
+#            cpu: 100m
+#            memory: 100Mi
+#        volumeMounts:
+#        - name: config
+#          mountPath: /etc/metricbeat.yml
+#          readOnly: true
+#          subPath: metricbeat.yml
+#        - name: modules
+#          mountPath: /usr/share/metricbeat/modules.d
+#          readOnly: true
+#      volumes:
+#      - name: config
+#        configMap:
+#          defaultMode: 0600
+#          name: metricbeat-config
+#      - name: modules
+#        configMap:
+#          defaultMode: 0600
+#          name: metricbeat-deployment-modules
+#---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/incubator/metricbeat/metricbeat-kubernetes-umich-prod.yaml
+++ b/incubator/metricbeat/metricbeat-kubernetes-umich-prod.yaml
@@ -197,69 +197,69 @@ data:
               - 'kubernetes.labels.app'
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
-apiVersion: apps/v1beta1
-kind: Deployment
-metadata:
-  name: metricbeat
-  namespace: kube-system
-  labels:
-    k8s-app: metricbeat
-spec:
-  template:
-    metadata:
-      labels:
-        k8s-app: metricbeat
-    spec:
-      serviceAccountName: metricbeat
-      containers:
-      - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.4.2
-        args: [
-          "-c", "/etc/metricbeat.yml",
-          "-e",
-        ]
-        env:
-        - name: ELASTICSEARCH_HOST
-          value: elasticsearch
-        - name: ELASTICSEARCH_PORT
-          value: "9200"
-        - name: ELASTICSEARCH_USERNAME
-          value: elastic
-        - name: ELASTICSEARCH_PASSWORD
-          value: changeme
-        - name: ELASTIC_CLOUD_ID
-          value:
-        - name: ELASTIC_CLOUD_AUTH
-          value:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        securityContext:
-          runAsUser: 0
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        volumeMounts:
-        - name: config
-          mountPath: /etc/metricbeat.yml
-          readOnly: true
-          subPath: metricbeat.yml
-        - name: modules
-          mountPath: /usr/share/metricbeat/modules.d
-          readOnly: true
-      volumes:
-      - name: config
-        configMap:
-          defaultMode: 0600
-          name: metricbeat-config
-      - name: modules
-        configMap:
-          defaultMode: 0600
-          name: metricbeat-deployment-modules
+#apiVersion: apps/v1beta1
+#kind: Deployment
+#metadata:
+#  name: metricbeat
+#  namespace: kube-system
+#  labels:
+#    k8s-app: metricbeat
+#spec:
+#  template:
+#    metadata:
+#      labels:
+#        k8s-app: metricbeat
+#    spec:
+#      serviceAccountName: metricbeat
+#      containers:
+#      - name: metricbeat
+#        image: docker.elastic.co/beats/metricbeat:6.4.2
+#        args: [
+#          "-c", "/etc/metricbeat.yml",
+#          "-e",
+#        ]
+#        env:
+#        - name: ELASTICSEARCH_HOST
+#          value: elasticsearch
+#        - name: ELASTICSEARCH_PORT
+#          value: "9200"
+#        - name: ELASTICSEARCH_USERNAME
+#          value: elastic
+#        - name: ELASTICSEARCH_PASSWORD
+#          value: changeme
+#        - name: ELASTIC_CLOUD_ID
+#          value:
+#        - name: ELASTIC_CLOUD_AUTH
+#          value:
+#        - name: POD_NAMESPACE
+#          valueFrom:
+#            fieldRef:
+#              fieldPath: metadata.namespace
+#        securityContext:
+#          runAsUser: 0
+#        resources:
+#          limits:
+#            memory: 200Mi
+#          requests:
+#            cpu: 100m
+#            memory: 100Mi
+#        volumeMounts:
+#        - name: config
+#          mountPath: /etc/metricbeat.yml
+#          readOnly: true
+#          subPath: metricbeat.yml
+#        - name: modules
+#          mountPath: /usr/share/metricbeat/modules.d
+#          readOnly: true
+#      volumes:
+#      - name: config
+#        configMap:
+#          defaultMode: 0600
+#          name: metricbeat-config
+#      - name: modules
+#        configMap:
+#          defaultMode: 0600
+#          name: metricbeat-deployment-modules
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/incubator/metricbeat/metricbeat-kubernetes-utah-bunt.yaml
+++ b/incubator/metricbeat/metricbeat-kubernetes-utah-bunt.yaml
@@ -197,70 +197,70 @@ data:
               - 'kubernetes.labels.app'
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
-apiVersion: apps/v1beta1
-kind: Deployment
-metadata:
-  name: metricbeat
-  namespace: kube-system
-  labels:
-    k8s-app: metricbeat
-spec:
-  template:
-    metadata:
-      labels:
-        k8s-app: metricbeat
-    spec:
-      serviceAccountName: metricbeat
-      containers:
-      - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.4.2
-        args: [
-          "-c", "/etc/metricbeat.yml",
-          "-e",
-        ]
-        env:
-        - name: ELASTICSEARCH_HOST
-          value: elasticsearch
-        - name: ELASTICSEARCH_PORT
-          value: "9200"
-        - name: ELASTICSEARCH_USERNAME
-          value: elastic
-        - name: ELASTICSEARCH_PASSWORD
-          value: changeme
-        - name: ELASTIC_CLOUD_ID
-          value:
-        - name: ELASTIC_CLOUD_AUTH
-          value:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        securityContext:
-          runAsUser: 0
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        volumeMounts:
-        - name: config
-          mountPath: /etc/metricbeat.yml
-          readOnly: true
-          subPath: metricbeat.yml
-        - name: modules
-          mountPath: /usr/share/metricbeat/modules.d
-          readOnly: true
-      volumes:
-      - name: config
-        configMap:
-          defaultMode: 0600
-          name: metricbeat-config
-      - name: modules
-        configMap:
-          defaultMode: 0600
-          name: metricbeat-deployment-modules
----
+#apiVersion: apps/v1beta1
+#kind: Deployment
+#metadata:
+#  name: metricbeat
+#  namespace: kube-system
+#  labels:
+#    k8s-app: metricbeat
+#spec:
+#  template:
+#    metadata:
+#      labels:
+#        k8s-app: metricbeat
+#    spec:
+#      serviceAccountName: metricbeat
+#      containers:
+#      - name: metricbeat
+#        image: docker.elastic.co/beats/metricbeat:6.4.2
+#        args: [
+#          "-c", "/etc/metricbeat.yml",
+#          "-e",
+#        ]
+#        env:
+#        - name: ELASTICSEARCH_HOST
+#          value: elasticsearch
+#        - name: ELASTICSEARCH_PORT
+#          value: "9200"
+#        - name: ELASTICSEARCH_USERNAME
+#          value: elastic
+#        - name: ELASTICSEARCH_PASSWORD
+#          value: changeme
+#        - name: ELASTIC_CLOUD_ID
+#          value:
+#        - name: ELASTIC_CLOUD_AUTH
+#          value:
+#        - name: POD_NAMESPACE
+#          valueFrom:
+#            fieldRef:
+#              fieldPath: metadata.namespace
+#        securityContext:
+#          runAsUser: 0
+#        resources:
+#          limits:
+#            memory: 200Mi
+#          requests:
+#            cpu: 100m
+#            memory: 100Mi
+#        volumeMounts:
+#        - name: config
+#          mountPath: /etc/metricbeat.yml
+#          readOnly: true
+#          subPath: metricbeat.yml
+#        - name: modules
+#          mountPath: /usr/share/metricbeat/modules.d
+#          readOnly: true
+#      volumes:
+#      - name: config
+#        configMap:
+#          defaultMode: 0600
+#          name: metricbeat-config
+#      - name: modules
+#        configMap:
+#          defaultMode: 0600
+#          name: metricbeat-deployment-modules
+#---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
This PR removes the singleton instance of metricbeat that runs independently of the daemonset. 

This was creating an additional extraneous "node" in the Infrastructure view on Kibana, and doesn't seem to report relevant information for us. 

I've tested this patch on umich-prod and uchicago-prod. 